### PR TITLE
Format files using checkstyle google_checks.xml

### DIFF
--- a/google_checks.xml
+++ b/google_checks.xml
@@ -1,0 +1,380 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name="Checker">
+  <module name="SuppressWarningsFilter"/>
+
+  <property name="charset" value="UTF-8"/>
+
+  <property name="severity" value="warning"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/filefilters/index.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+  <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+           default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See http://checkstyle.org/checks/whitespace/index.html -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="120"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+
+  <module name="TreeWalker">
+    <module name="OuterTypeFilename"/>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+      <property name="format"
+               value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+      <property name="message"
+               value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+    </module>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowEscapesForControlCharacters" value="true"/>
+      <property name="allowByTailComment" value="true"/>
+      <property name="allowNonPrintableEscapes" value="true"/>
+    </module>
+    <module name="AvoidStarImport"/>
+    <module name="OneTopLevelClass"/>
+    <module name="NoLineWrap">
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+    </module>
+    <module name="EmptyBlock">
+      <property name="option" value="TEXT"/>
+      <property name="tokens"
+               value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+    </module>
+    <module name="NeedBraces">
+      <property name="tokens"
+               value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="tokens"
+               value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlySame"/>
+      <property name="tokens"
+               value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="option" value="alone"/>
+      <property name="tokens"
+               value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
+                                     or preceding-sibling::*[last()][self::LCURLY]]"/>
+    </module>
+    <module name="WhitespaceAfter">
+      <property name="tokens"
+               value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_RETURN,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, DO_WHILE, ELLIPSIS,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_CATCH, LAMBDA,
+                    LITERAL_YIELD, LITERAL_CASE"/>
+    </module>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyTypes" value="true"/>
+      <property name="allowEmptyLoops" value="true"/>
+      <property name="ignoreEnhancedForColon" value="false"/>
+      <property name="tokens"
+               value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+      <message key="ws.notFollowed"
+              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
+               may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+      <message key="ws.notPreceded"
+              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="OneStatementPerLine"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="ArrayTypeStyle"/>
+    <module name="FallThrough"/>
+    <module name="UpperEll"/>
+    <module name="ModifierOrder"/>
+    <module name="EmptyLineSeparator">
+      <property name="tokens"
+               value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapDot"/>
+      <property name="tokens" value="DOT"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapComma"/>
+      <property name="tokens" value="COMMA"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/259 -->
+      <property name="id" value="SeparatorWrapEllipsis"/>
+      <property name="tokens" value="ELLIPSIS"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/258 -->
+      <property name="id" value="SeparatorWrapArrayDeclarator"/>
+      <property name="tokens" value="ARRAY_DECLARATOR"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapMethodRef"/>
+      <property name="tokens" value="METHOD_REF"/>
+      <property name="option" value="nl"/>
+    </module>
+    <!-- <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+      <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+    </module> -->
+    <module name="TypeName">
+      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    ANNOTATION_DEF, RECORD_DEF"/>
+      <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MemberName">
+      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+      <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="CatchParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LocalVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="PatternVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ClassTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordComponentName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Record component name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+               value="Record type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="InterfaceTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="NoFinalizer"/>
+    <module name="GenericWhitespace">
+      <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+      <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+      <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+      <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="braceAdjustment" value="2"/>
+      <property name="caseIndent" value="4"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="lineWrappingIndentation" value="8"/>
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+    <!-- <module name="AbbreviationAsWordInName">
+      <property name="ignoreFinal" value="false"/>
+      <property name="allowedAbbreviationLength" value="0"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
+                    RECORD_COMPONENT_DEF"/>
+    </module> -->
+    <module name="NoWhitespaceBeforeCaseDefaultColon"/>
+    <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="CustomImportOrder">
+      <property name="sortImportsInGroupAlphabetically" value="false"/>
+      <property name="separateLineBetweenGroups" value="true"/>
+      <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+      <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
+    </module>
+    <module name="MethodParamPad">
+      <property name="tokens"
+               value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="tokens"
+               value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF"/>
+      <property name="allowLineBreaks" value="true"/>
+    </module>
+    <module name="ParenPad">
+      <property name="tokens"
+               value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                    RECORD_DEF"/>
+    </module>
+    <module name="OperatorWrap">
+      <property name="option" value="NL"/>
+      <property name="tokens"
+               value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
+                    TYPE_EXTENSION_AND "/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationMostCases"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                      RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationVariables"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
+      <property name="allowSamelineMultipleAnnotations" value="true"/>
+    </module>
+    <!-- <module name="NonEmptyAtclauseDescription"/>
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocTagContinuationIndentation"/>
+    <module name="SummaryJavadoc">
+      <property name="forbiddenSummaryFragments"
+               value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+    </module> -->
+    <!-- <module name="JavadocParagraph"/>
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="target"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+    </module>
+    <module name="JavadocMethod">
+      <property name="accessModifiers" value="public"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+    </module> -->
+    <!-- <module name="MissingJavadocMethod">
+      <property name="scope" value="public"/>
+      <property name="minLineCount" value="2"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+                                   COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="MissingJavadocType">
+      <property name="scope" value="protected"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF"/>
+      <property name="excludeScope" value="nothing"/>
+    </module> -->
+    <module name="MethodName">
+      <property name="format" value="^[a-z][a-z0-9]\w*$"/>
+      <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="SingleLineJavadoc"/>
+    <module name="EmptyCatchBlock">
+      <property name="exceptionVariableName" value="expected"/>
+    </module>
+    <module name="CommentsIndentation">
+      <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+    </module>
+    <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+             default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
+    <module name="SuppressWarningsHolder" />
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
+      <property name="checkFormat" value="$1" />
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)"/>
+      <!-- $1 refers to the first match group in the regex defined in commentFormat -->
+      <property name="checkFormat" value="$1"/>
+      <!-- The check is suppressed in the next line of code after the comment -->
+      <property name="influenceFormat" value="1"/>
+    </module>
+  </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,35 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.4.0</version>
+        <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>10.17.0</version>
+            </dependency>
+          </dependencies>
+        <configuration>
+          <configLocation>google_checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failsOnError>true</failsOnError>
+          <violationSeverity>warning</violationSeverity>
+          <linkXRef>false</linkXRef>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>net.nicoulaj.maven.plugins</groupId>
         <artifactId>checksum-maven-plugin</artifactId>
         <version>1.10</version>

--- a/src/main/java/org/project_kessel/clients/authn/AuthenticationConfig.java
+++ b/src/main/java/org/project_kessel/clients/authn/AuthenticationConfig.java
@@ -1,11 +1,6 @@
 package org.project_kessel.clients.authn;
 
 public class AuthenticationConfig {
-    public enum AuthMode {
-        DISABLED,
-        OIDC_CLIENT_CREDENTIALS
-    }
-
     private AuthMode authMode;
 
     public AuthMode mode() {
@@ -14,5 +9,10 @@ public class AuthenticationConfig {
 
     public void setMode(AuthMode authMode) {
         this.authMode = authMode;
+    }
+
+    public enum AuthMode {
+        DISABLED,
+        OIDC_CLIENT_CREDENTIALS
     }
 }

--- a/src/main/java/org/project_kessel/clients/authn/CallCredentialsFactory.java
+++ b/src/main/java/org/project_kessel/clients/authn/CallCredentialsFactory.java
@@ -11,13 +11,16 @@ public class CallCredentialsFactory {
 
     public static CallCredentials create(AuthenticationConfig authnConfig) throws CallCredentialsCreationException {
         if (authnConfig == null) {
-            throw new CallCredentialsCreationException("AuthenticationConfig is required to create CallCredentials and must not be null.");
+            throw new CallCredentialsCreationException(
+                    "AuthenticationConfig is required to create CallCredentials and must not be null.");
         }
 
         try {
             switch (authnConfig.mode()) {
-                case DISABLED: return null;
-                case OIDC_CLIENT_CREDENTIALS: return new OIDCClientCredentialsCallCredentials(authnConfig);
+                case DISABLED:
+                    return null;
+                case OIDC_CLIENT_CREDENTIALS:
+                    return new OIDCClientCredentialsCallCredentials(authnConfig);
             }
         } catch (OIDCClientCredentialsCallCredentials.OIDCClientCredentialsCallCredentialsException e) {
             throw new CallCredentialsCreationException("Failed to create OIDCClientCredentialsCallCredentials.", e);

--- a/src/main/java/org/project_kessel/clients/authn/oidc/client/OIDCClientCredentialsAuthenticationConfig.java
+++ b/src/main/java/org/project_kessel/clients/authn/oidc/client/OIDCClientCredentialsAuthenticationConfig.java
@@ -1,8 +1,7 @@
 package org.project_kessel.clients.authn.oidc.client;
 
-import org.project_kessel.clients.authn.AuthenticationConfig;
-
 import java.util.Optional;
+import org.project_kessel.clients.authn.AuthenticationConfig;
 
 public class OIDCClientCredentialsAuthenticationConfig extends AuthenticationConfig {
     OIDCClientCredentialsConfig credentialsConfig;
@@ -58,7 +57,8 @@ public class OIDCClientCredentialsAuthenticationConfig extends AuthenticationCon
             return oidcClientCredentialsMinterImplementation;
         }
 
-        public void setOidcClientCredentialsMinterImplementation(Optional<String> oidcClientCredentialsMinterImplementation) {
+        public void setOidcClientCredentialsMinterImplementation(
+                Optional<String> oidcClientCredentialsMinterImplementation) {
             this.oidcClientCredentialsMinterImplementation = oidcClientCredentialsMinterImplementation;
         }
     }

--- a/src/main/java/org/project_kessel/clients/authn/oidc/client/OIDCClientCredentialsCallCredentials.java
+++ b/src/main/java/org/project_kessel/clients/authn/oidc/client/OIDCClientCredentialsCallCredentials.java
@@ -2,38 +2,70 @@ package org.project_kessel.clients.authn.oidc.client;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
-import org.project_kessel.clients.authn.AuthenticationConfig;
-
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
+import org.project_kessel.clients.authn.AuthenticationConfig;
 
 public class OIDCClientCredentialsCallCredentials extends io.grpc.CallCredentials {
-    static final Metadata.Key<String> authorizationKey = Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+    static final Metadata.Key<String> authorizationKey =
+            Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
 
     private final OIDCClientCredentialsAuthenticationConfig.OIDCClientCredentialsConfig clientCredentialsConfig;
     private final OIDCClientCredentialsMinter minter;
 
-    private final AtomicReference<OIDCClientCredentialsMinter.BearerHeader> storedBearerHeaderRef = new AtomicReference<>();
+    private final AtomicReference<OIDCClientCredentialsMinter.BearerHeader> storedBearerHeaderRef =
+            new AtomicReference<>();
 
-    public OIDCClientCredentialsCallCredentials(AuthenticationConfig authnConfig) throws OIDCClientCredentialsCallCredentialsException {
+    public OIDCClientCredentialsCallCredentials(AuthenticationConfig authnConfig)
+            throws OIDCClientCredentialsCallCredentialsException {
         this.clientCredentialsConfig = validateAndExtractConfig(authnConfig);
 
         Optional<String> minterImpl = clientCredentialsConfig.oidcClientCredentialsMinterImplementation();
         try {
-            if(minterImpl.isPresent()) {
+            if (minterImpl.isPresent()) {
                 this.minter = OIDCClientCredentialsMinter.forName(minterImpl.get());
             } else {
                 this.minter = OIDCClientCredentialsMinter.forDefaultImplementation();
             }
         } catch (OIDCClientCredentialsMinter.OIDCClientCredentialsMinterException e) {
-            throw new OIDCClientCredentialsCallCredentialsException("Couldn't create GrpcCallCredentials because minter impl not instantiated.", e);
+            throw new OIDCClientCredentialsCallCredentialsException(
+                    "Couldn't create GrpcCallCredentials because minter impl not instantiated.", e);
         }
     }
 
-    OIDCClientCredentialsCallCredentials(OIDCClientCredentialsAuthenticationConfig.OIDCClientCredentialsConfig clientCredentialsConfig, OIDCClientCredentialsMinter minter) {
+    OIDCClientCredentialsCallCredentials(
+            OIDCClientCredentialsAuthenticationConfig.OIDCClientCredentialsConfig clientCredentialsConfig,
+            OIDCClientCredentialsMinter minter) {
         this.clientCredentialsConfig = clientCredentialsConfig;
         this.minter = minter;
+    }
+
+    static OIDCClientCredentialsAuthenticationConfig.OIDCClientCredentialsConfig validateAndExtractConfig(
+            AuthenticationConfig authnConfig) throws OIDCClientCredentialsCallCredentialsException {
+        if (!(authnConfig instanceof OIDCClientCredentialsAuthenticationConfig)) {
+            throw new OIDCClientCredentialsCallCredentialsException(
+                    "ClientCredentialsConfig is required for OIDC client credentials authentication method.");
+        }
+
+        var oidcClientCredentialsAuthenticationConfig = (OIDCClientCredentialsAuthenticationConfig) authnConfig;
+        if (oidcClientCredentialsAuthenticationConfig.clientCredentialsConfig() == null) {
+            throw new OIDCClientCredentialsCallCredentialsException("ClientCredentialsConfig cannot be null.");
+        }
+
+        if (oidcClientCredentialsAuthenticationConfig.clientCredentialsConfig().issuer() == null) {
+            throw new OIDCClientCredentialsCallCredentialsException("ClientCredentialsConfig Issuer must not be null.");
+        }
+        if (oidcClientCredentialsAuthenticationConfig.clientCredentialsConfig().clientId() == null) {
+            throw new OIDCClientCredentialsCallCredentialsException(
+                    "ClientCredentialsConfig Client id must not be null.");
+        }
+        if (oidcClientCredentialsAuthenticationConfig.clientCredentialsConfig().clientSecret() == null) {
+            throw new OIDCClientCredentialsCallCredentialsException(
+                    "ClientCredentialsConfig Client secret must not be null.");
+        }
+
+        return oidcClientCredentialsAuthenticationConfig.clientCredentialsConfig();
     }
 
     @Override
@@ -42,7 +74,8 @@ public class OIDCClientCredentialsCallCredentials extends io.grpc.CallCredential
             try {
                 synchronized (storedBearerHeaderRef) {
                     if (storedBearerHeaderRef.get() == null || storedBearerHeaderRef.get().isExpired()) {
-                        storedBearerHeaderRef.set(minter.authenticateAndRetrieveAuthorizationHeader(clientCredentialsConfig));
+                        storedBearerHeaderRef.set(
+                                minter.authenticateAndRetrieveAuthorizationHeader(clientCredentialsConfig));
                     }
 
                     Metadata headers = new Metadata();
@@ -62,29 +95,6 @@ public class OIDCClientCredentialsCallCredentials extends io.grpc.CallCredential
         synchronized (storedBearerHeaderRef) {
             storedBearerHeaderRef.set(null);
         }
-    }
-
-    static OIDCClientCredentialsAuthenticationConfig.OIDCClientCredentialsConfig validateAndExtractConfig(AuthenticationConfig authnConfig) throws OIDCClientCredentialsCallCredentialsException {
-        if (!(authnConfig instanceof OIDCClientCredentialsAuthenticationConfig)) {
-            throw new OIDCClientCredentialsCallCredentialsException("ClientCredentialsConfig is required for OIDC client credentials authentication method.");
-        }
-
-        var oidcClientCredentialsAuthenticationConfig = (OIDCClientCredentialsAuthenticationConfig) authnConfig;
-        if(oidcClientCredentialsAuthenticationConfig.clientCredentialsConfig() == null) {
-            throw new OIDCClientCredentialsCallCredentialsException("ClientCredentialsConfig cannot be null.");
-        }
-
-        if(oidcClientCredentialsAuthenticationConfig.clientCredentialsConfig().issuer() == null) {
-            throw new OIDCClientCredentialsCallCredentialsException("ClientCredentialsConfig Issuer must not be null.");
-        }
-        if(oidcClientCredentialsAuthenticationConfig.clientCredentialsConfig().clientId() == null) {
-            throw new OIDCClientCredentialsCallCredentialsException("ClientCredentialsConfig Client id must not be null.");
-        }
-        if(oidcClientCredentialsAuthenticationConfig.clientCredentialsConfig().clientSecret() == null) {
-            throw new OIDCClientCredentialsCallCredentialsException("ClientCredentialsConfig Client secret must not be null.");
-        }
-
-        return oidcClientCredentialsAuthenticationConfig.clientCredentialsConfig();
     }
 
     public static class OIDCClientCredentialsCallCredentialsException extends Exception {

--- a/src/main/java/org/project_kessel/clients/test/TestClientsManager.java
+++ b/src/main/java/org/project_kessel/clients/test/TestClientsManager.java
@@ -10,18 +10,20 @@ import org.project_kessel.clients.KesselClientsManager;
 import org.project_kessel.clients.authn.AuthenticationConfig;
 
 public class TestClientsManager extends KesselClientsManager {
+    private static final String CHANNEL_MANAGER_KEY = TestClientsManager.class.getName();
+
     protected TestClientsManager(Channel channel) {
         super(channel);
     }
-
-    private static final String CHANNEL_MANAGER_KEY = TestClientsManager.class.getName();
 
     public static TestClientsManager forInsecureClients(String targetUrl) {
         return new TestClientsManager(ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forInsecureClients(targetUrl));
     }
 
-    public static TestClientsManager forInsecureClients(String targetUrl, AuthenticationConfig authnConfig) throws RuntimeException {
-        return new TestClientsManager(ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forInsecureClients(targetUrl, authnConfig));
+    public static TestClientsManager forInsecureClients(String targetUrl, AuthenticationConfig authnConfig)
+            throws RuntimeException {
+        return new TestClientsManager(
+                ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forInsecureClients(targetUrl, authnConfig));
     }
 
     public static TestClientsManager forSecureClients(String targetUrl) {
@@ -29,7 +31,8 @@ public class TestClientsManager extends KesselClientsManager {
     }
 
     public static TestClientsManager forSecureClients(String targetUrl, AuthenticationConfig authnConfig) {
-        return new TestClientsManager(ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forSecureClients(targetUrl, authnConfig));
+        return new TestClientsManager(
+                ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forSecureClients(targetUrl, authnConfig));
     }
 
     public static void shutdownAll() {
@@ -44,8 +47,10 @@ public class TestClientsManager extends KesselClientsManager {
         return new TestClient(channel);
     }
 
-    public static class TestClient extends KesselClient<KesselTestServiceGrpc.KesselTestServiceStub,KesselTestServiceGrpc.KesselTestServiceBlockingStub> {
-        protected TestClient(KesselTestServiceGrpc.KesselTestServiceStub asyncStub, KesselTestServiceGrpc.KesselTestServiceBlockingStub blockingStub) {
+    public static class TestClient extends KesselClient<KesselTestServiceGrpc.KesselTestServiceStub,
+            KesselTestServiceGrpc.KesselTestServiceBlockingStub> {
+        protected TestClient(KesselTestServiceGrpc.KesselTestServiceStub asyncStub,
+                             KesselTestServiceGrpc.KesselTestServiceBlockingStub blockingStub) {
             super(asyncStub, blockingStub);
         }
 

--- a/src/test/java/org/project_kessel/clients/ChannelManagerTest.java
+++ b/src/test/java/org/project_kessel/clients/ChannelManagerTest.java
@@ -1,16 +1,18 @@
 package org.project_kessel.clients;
 
-import io.grpc.Channel;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import io.grpc.Channel;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 class ChannelManagerTest {
     ChannelManager defaultChannelManager = ChannelManager.getInstance("defaultChannelManager");
@@ -100,7 +102,7 @@ class ChannelManagerTest {
                 final int j = i;
                 service.submit(() -> {
                     Channel channel;
-                    if(j % 2 == 0) {
+                    if (j % 2 == 0) {
                         channel = defaultChannelManager.forInsecureClients("localhost" + j);
                     } else {
                         channel = defaultChannelManager.forSecureClients("localhost" + j);
@@ -128,7 +130,7 @@ class ChannelManagerTest {
                 final int j = i - numberOfThreads * 2 / 3;
                 service.submit(() -> {
                     Channel channel;
-                    if(j % 2 == 0) {
+                    if (j % 2 == 0) {
                         channel = defaultChannelManager.forInsecureClients("localhost" + j);
                     } else {
                         channel = defaultChannelManager.forSecureClients("localhost" + j);
@@ -140,7 +142,7 @@ class ChannelManagerTest {
             }
             latch2.await();
             latch3.await();
-        } catch(Exception e) {
+        } catch (Exception e) {
             fail("Should not have thrown any exception");
         }
     }
@@ -162,8 +164,8 @@ class ChannelManagerTest {
         insecureField.setAccessible(true);
         var secureField = ChannelManager.class.getDeclaredField("secureChannels");
         secureField.setAccessible(true);
-        var insecureChannels = (HashMap<?,?>)insecureField.get(defaultChannelManager);
-        var secureChannels = (HashMap<?,?>)secureField.get(defaultChannelManager);
+        var insecureChannels = (HashMap<?, ?>) insecureField.get(defaultChannelManager);
+        var secureChannels = (HashMap<?, ?>) secureField.get(defaultChannelManager);
 
         assertEquals(2, insecureChannels.size());
         assertEquals(2, secureChannels.size());
@@ -173,34 +175,34 @@ class ChannelManagerTest {
     void testCreateAndShutdownPatternsInternal() throws Exception {
         var insecureField = ChannelManager.class.getDeclaredField("insecureChannels");
         insecureField.setAccessible(true);
-        var insecureChannelsSize = ((HashMap<?,?>)insecureField.get(defaultChannelManager)).size();
+        var insecureChannelsSize = ((HashMap<?, ?>) insecureField.get(defaultChannelManager)).size();
 
         assertEquals(0, insecureChannelsSize);
 
         var channel = defaultChannelManager.forInsecureClients("localhost:8080");
-        insecureChannelsSize = ((HashMap<?,?>)insecureField.get(defaultChannelManager)).size();
+        insecureChannelsSize = ((HashMap<?, ?>) insecureField.get(defaultChannelManager)).size();
         assertEquals(1, insecureChannelsSize);
 
         defaultChannelManager.shutdownChannel(channel);
-        insecureChannelsSize = ((HashMap<?,?>)insecureField.get(defaultChannelManager)).size();
+        insecureChannelsSize = ((HashMap<?, ?>) insecureField.get(defaultChannelManager)).size();
         assertEquals(0, insecureChannelsSize);
 
         /* Shouldn't throw exception if executed twice */
         defaultChannelManager.shutdownChannel(channel);
-        insecureChannelsSize = ((HashMap<?,?>)insecureField.get(defaultChannelManager)).size();
+        insecureChannelsSize = ((HashMap<?, ?>) insecureField.get(defaultChannelManager)).size();
         assertEquals(0, insecureChannelsSize);
 
         var channel2 = defaultChannelManager.forInsecureClients("localhost:8080");
-        insecureChannelsSize = ((HashMap<?,?>)insecureField.get(defaultChannelManager)).size();
+        insecureChannelsSize = ((HashMap<?, ?>) insecureField.get(defaultChannelManager)).size();
         assertEquals(1, insecureChannelsSize);
         assertNotEquals(channel, channel2);
 
         defaultChannelManager.forInsecureClients("localhost:8081");
-        insecureChannelsSize = ((HashMap<?,?>)insecureField.get(defaultChannelManager)).size();
+        insecureChannelsSize = ((HashMap<?, ?>) insecureField.get(defaultChannelManager)).size();
         assertEquals(2, insecureChannelsSize);
 
         defaultChannelManager.shutdownAll();
-        insecureChannelsSize = ((HashMap<?,?>)insecureField.get(defaultChannelManager)).size();
+        insecureChannelsSize = ((HashMap<?, ?>) insecureField.get(defaultChannelManager)).size();
         assertEquals(0, insecureChannelsSize);
     }
 }

--- a/src/test/java/org/project_kessel/clients/authn/CallCredentialsFactoryTest.java
+++ b/src/test/java/org/project_kessel/clients/authn/CallCredentialsFactoryTest.java
@@ -1,44 +1,12 @@
 package org.project_kessel.clients.authn;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.project_kessel.clients.authn.oidc.client.OIDCClientCredentialsAuthenticationConfig;
 
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.fail;
-
 public class CallCredentialsFactoryTest {
-    @Test
-    void testCreateOIDCClientCallCredentials() {
-        AuthenticationConfig authnConfig = dummyAuthConfigWithGoodOIDCClientCredentials();
-        try {
-            CallCredentialsFactory.create(authnConfig);
-        } catch (CallCredentialsFactory.CallCredentialsCreationException e) {
-            fail("CallCredentialsFactory creation for OIDC client should not throw an exception when OIDC client config is good.");
-        }
-    }
-
-    @Test
-    void testFailToCreateCallCredentialsWhenAuthnConfigEmpty() {
-        AuthenticationConfig authnConfig = null;
-        try {
-            CallCredentialsFactory.create(authnConfig);
-            fail("CallCredentialsFactory creation for OIDC client should throw an exception when OIDC client config is empty.");
-        } catch (CallCredentialsFactory.CallCredentialsCreationException e) {
-        }
-    }
-
-    @Test
-    void testFailToCreateCallCredentialsForOIDCWhenConfigEmpty() {
-        var authnConfig = new OIDCClientCredentialsAuthenticationConfig();
-        authnConfig.setMode(AuthenticationConfig.AuthMode.OIDC_CLIENT_CREDENTIALS);
-        try {
-            CallCredentialsFactory.create(authnConfig);
-            fail("CallCredentialsFactory creation for OIDC client should throw an exception when OIDC client config is empty.");
-        } catch (CallCredentialsFactory.CallCredentialsCreationException e) {
-        }
-    }
-
     public static OIDCClientCredentialsAuthenticationConfig dummyAuthConfigWithGoodOIDCClientCredentials() {
         var oidcClientCredentialsConfig = new OIDCClientCredentialsAuthenticationConfig.OIDCClientCredentialsConfig();
         oidcClientCredentialsConfig.setIssuer("http://localhost:8090");
@@ -52,5 +20,41 @@ public class CallCredentialsFactoryTest {
         authnConfig.setCredentialsConfig(oidcClientCredentialsConfig);
 
         return authnConfig;
+    }
+
+    @Test
+    void testCreateOIDCClientCallCredentials() {
+        AuthenticationConfig authnConfig = dummyAuthConfigWithGoodOIDCClientCredentials();
+        try {
+            CallCredentialsFactory.create(authnConfig);
+        } catch (CallCredentialsFactory.CallCredentialsCreationException e) {
+            fail("CallCredentialsFactory creation for OIDC client "
+                    + "should not throw an exception when OIDC client config is good.");
+        }
+    }
+
+    @Test
+    void testFailToCreateCallCredentialsWhenAuthnConfigEmpty() {
+        AuthenticationConfig authnConfig = null;
+        try {
+            CallCredentialsFactory.create(authnConfig);
+            fail("CallCredentialsFactory creation for OIDC client "
+                    + "should throw an exception when OIDC client config is empty.");
+        } catch (CallCredentialsFactory.CallCredentialsCreationException e) {
+            // empty catch block
+        }
+    }
+
+    @Test
+    void testFailToCreateCallCredentialsForOIDCWhenConfigEmpty() {
+        var authnConfig = new OIDCClientCredentialsAuthenticationConfig();
+        authnConfig.setMode(AuthenticationConfig.AuthMode.OIDC_CLIENT_CREDENTIALS);
+        try {
+            CallCredentialsFactory.create(authnConfig);
+            fail("CallCredentialsFactory creation for OIDC client "
+                    + "should throw an exception when OIDC client config is empty.");
+        } catch (CallCredentialsFactory.CallCredentialsCreationException e) {
+            // empty catch block
+        }
     }
 }

--- a/src/test/java/org/project_kessel/clients/authn/oidc/client/OIDCClientCredentialsMinterTest.java
+++ b/src/test/java/org/project_kessel/clients/authn/oidc/client/OIDCClientCredentialsMinterTest.java
@@ -1,12 +1,14 @@
 package org.project_kessel.clients.authn.oidc.client;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.project_kessel.clients.authn.oidc.client.OIDCClientCredentialsMinter.getExpiryDateFromExpiresIn;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.project_kessel.clients.authn.oidc.client.OIDCClientCredentialsMinter.getExpiryDateFromExpiresIn;
+import org.junit.jupiter.api.Test;
 
 class OIDCClientCredentialsMinterTest {
 
@@ -17,7 +19,8 @@ class OIDCClientCredentialsMinterTest {
             var minter = OIDCClientCredentialsMinter.forClass(defaultMinterClass);
             assertInstanceOf(defaultMinterClass, minter);
         } catch (OIDCClientCredentialsMinter.OIDCClientCredentialsMinterException e) {
-            fail("Creating minter from default implementation name should not throw an OIDCClientCredentialsMinterException");
+            fail("Creating minter from default implementation name "
+                    + "should not throw an OIDCClientCredentialsMinterException");
         }
     }
 
@@ -28,7 +31,8 @@ class OIDCClientCredentialsMinterTest {
             var minter = OIDCClientCredentialsMinter.forClass(testMinterClass);
             assertInstanceOf(testMinterClass, minter);
         } catch (OIDCClientCredentialsMinter.OIDCClientCredentialsMinterException e) {
-            fail("Creating minter from test implementation name should not throw an OIDCClientCredentialsMinterException");
+            fail("Creating minter from test implementation name "
+                    + "should not throw an OIDCClientCredentialsMinterException");
         }
     }
 
@@ -38,7 +42,8 @@ class OIDCClientCredentialsMinterTest {
         try {
             OIDCClientCredentialsMinter.forName(testMinterName);
         } catch (OIDCClientCredentialsMinter.OIDCClientCredentialsMinterException e) {
-            fail("Creating minter from test implementation name should not throw an OIDCClientCredentialsMinterException");
+            fail("Creating minter from test implementation name "
+                    + "should not throw an OIDCClientCredentialsMinterException");
         }
     }
 
@@ -50,7 +55,8 @@ class OIDCClientCredentialsMinterTest {
         } catch (OIDCClientCredentialsMinter.OIDCClientCredentialsMinterException e) {
             return;
         }
-        fail("Creating minter from not existent implementation name should throw an OIDCClientCredentialsMinterException");
+        fail("Creating minter from not existent implementation name "
+                + "should throw an OIDCClientCredentialsMinterException");
     }
 
     @Test
@@ -89,7 +95,9 @@ class OIDCClientCredentialsMinterTest {
         }
 
         @Override
-        public BearerHeader authenticateAndRetrieveAuthorizationHeader(OIDCClientCredentialsAuthenticationConfig.OIDCClientCredentialsConfig clientConfig) throws OIDCClientCredentialsMinterException {
+        public BearerHeader authenticateAndRetrieveAuthorizationHeader(
+                OIDCClientCredentialsAuthenticationConfig.OIDCClientCredentialsConfig clientConfig)
+                throws OIDCClientCredentialsMinterException {
             return null;
         }
     }

--- a/src/test/java/org/project_kessel/clients/authn/oidc/client/nimbus/NimbusOIDCClientCredentialsMinterTest.java
+++ b/src/test/java/org/project_kessel/clients/authn/oidc/client/nimbus/NimbusOIDCClientCredentialsMinterTest.java
@@ -1,18 +1,21 @@
 package org.project_kessel.clients.authn.oidc.client.nimbus;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.junit.jupiter.api.Test;
 import org.project_kessel.clients.authn.CallCredentialsFactoryTest;
 import org.project_kessel.clients.authn.oidc.client.OIDCClientCredentialsMinter;
 import org.project_kessel.clients.fake.FakeIdp;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class NimbusOIDCClientCredentialsMinterTest {
 
     @Test
     void shouldReturnBearerHeaderWhenIdPAuthenticates() {
         var minter = new NimbusOIDCClientCredentialsMinter();
-        var config = CallCredentialsFactoryTest.dummyAuthConfigWithGoodOIDCClientCredentials().clientCredentialsConfig();
+        var config =
+                CallCredentialsFactoryTest.dummyAuthConfigWithGoodOIDCClientCredentials().clientCredentialsConfig();
         OIDCClientCredentialsMinter.BearerHeader bearerHeader = null;
         try {
             FakeIdp fakeIdp = new FakeIdp(8090);
@@ -30,7 +33,8 @@ public class NimbusOIDCClientCredentialsMinterTest {
     @Test
     void shouldThrowExceptionWhenIdPAuthenticationFails() {
         var minter = new NimbusOIDCClientCredentialsMinter();
-        var config = CallCredentialsFactoryTest.dummyAuthConfigWithGoodOIDCClientCredentials().clientCredentialsConfig();
+        var config =
+                CallCredentialsFactoryTest.dummyAuthConfigWithGoodOIDCClientCredentials().clientCredentialsConfig();
         FakeIdp fakeIdp = new FakeIdp(8090, false);
         try {
             fakeIdp.start();
@@ -38,7 +42,7 @@ public class NimbusOIDCClientCredentialsMinterTest {
             fail("Should throw exception if authn is not successful.");
         } catch (OIDCClientCredentialsMinter.OIDCClientCredentialsMinterException e) {
             // success
-        } catch(Exception e) {
+        } catch (Exception e) {
             fail("OIDCClientCredentialsMinterException expected.");
         } finally {
             fakeIdp.stop();

--- a/src/test/java/org/project_kessel/clients/fake/FakeIdp.java
+++ b/src/test/java/org/project_kessel/clients/fake/FakeIdp.java
@@ -3,7 +3,6 @@ package org.project_kessel.clients.fake;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -33,7 +32,7 @@ public class FakeIdp {
             throw new RuntimeException(e);
         }
         server.createContext("/.well-known/openid-configuration", new WellKnownHandler());
-        if(alwaysSucceedOrFailAuthn) {
+        if (alwaysSucceedOrFailAuthn) {
             server.createContext("/token", new TokenHandler());
         } else {
             server.createContext("/token", new UnauthorizedHandler());
@@ -50,16 +49,16 @@ public class FakeIdp {
     static class TokenHandler implements HttpHandler {
         @Override
         public void handle(HttpExchange t) throws IOException {
-            String response = "{\n" +
-                    "      \"iss\": \"http://localhost:8090/\",\n" +
-                    "      \"aud\": \"us\",\n" +
-                    "      \"sub\": \"usr_123\",\n" +
-                    "      \"scope\": \"read write\",\n" +
-                    "      \"iat\": 1458785796,\n" +
-                    "      \"exp\": 1458872196,\n" +
-                    "      \"token_type\": \"Bearer\",\n" +
-                    "      \"access_token\": \"blah\"\n" +
-                    "}";
+            String response = "{\n"
+                    + "      \"iss\": \"http://localhost:8090/\",\n"
+                    + "      \"aud\": \"us\",\n"
+                    + "      \"sub\": \"usr_123\",\n"
+                    + "      \"scope\": \"read write\",\n"
+                    + "      \"iat\": 1458785796,\n"
+                    + "      \"exp\": 1458872196,\n"
+                    + "      \"token_type\": \"Bearer\",\n"
+                    + "      \"access_token\": \"blah\"\n"
+                    + "}";
             t.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
             t.sendResponseHeaders(200, response.length());
             OutputStream os = t.getResponseBody();
@@ -71,7 +70,9 @@ public class FakeIdp {
     static class UnauthorizedHandler implements HttpHandler {
         @Override
         public void handle(HttpExchange t) throws IOException {
-            String response = "{\"error_description\":\"Access denied by resource owner or authorization server\",\"error\":\"access_denied\"}";
+            String response =
+                    "{\"error_description\":\"Access denied by resource owner or authorization server\","
+                            + "\"error\":\"access_denied\"}";
 
             // https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint (3.1.3.4. Token Error Response)
             t.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
@@ -85,16 +86,20 @@ public class FakeIdp {
     static class WellKnownHandler implements HttpHandler {
         @Override
         public void handle(HttpExchange t) throws IOException {
-            String response = "{\n" +
-                    "\t\"issuer\":\"http://localhost:8090\",\n" +
-                    "\t\"authorization_endpoint\":\"http://localhost:8090/protocol/openid-connect/auth\",\n" +
-                    "\t\"token_endpoint\":\"http://localhost:8090/token\",\n" +
-                    "\t\"introspection_endpoint\":\"http://localhost:8090/token/introspect\",\n" +
-                    "\t\"jwks_uri\":\"http://localhost:8090/certs\",\n" +
-                    "\t\"response_types_supported\":[\"code\",\"none\",\"id_token\",\"token\",\"id_token token\",\"code id_token\",\"code token\",\"code id_token token\"],\n" +
-                    "\t\"token_endpoint_auth_methods_supported\":[\"private_key_jwt\",\"client_secret_basic\",\"client_secret_post\",\"tls_client_auth\",\"client_secret_jwt\"],\n" +
-                    "\t\"subject_types_supported\":[\"public\",\"pairwise\"]\n" +
-                    "}";
+            String response = "{\n"
+                    + "\t\"issuer\":\"http://localhost:8090\",\n"
+                    + "\t\"authorization_endpoint\":\"http://localhost:8090/protocol/openid-connect/auth\",\n"
+                    + "\t\"token_endpoint\":\"http://localhost:8090/token\",\n"
+                    + "\t\"introspection_endpoint\":\"http://localhost:8090/token/introspect\",\n"
+                    + "\t\"jwks_uri\":\"http://localhost:8090/certs\",\n"
+                    + "\t\"response_types_supported\":[\"code\",\"none\",\"id_token\",\"token\",\"id_token token\"," 
+                    +
+                    "\"code id_token\",\"code token\",\"code id_token token\"],\n"
+                    + "\t\"token_endpoint_auth_methods_supported\":[\"private_key_jwt\",\"client_secret_basic\"," 
+                    +
+                    "\"client_secret_post\",\"tls_client_auth\",\"client_secret_jwt\"],\n"
+                    + "\t\"subject_types_supported\":[\"public\",\"pairwise\"]\n"
+                    + "}";
             t.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
             t.sendResponseHeaders(200, response.length());
             OutputStream os = t.getResponseBody();

--- a/src/test/java/org/project_kessel/clients/test/TestClientsManagerTest.java
+++ b/src/test/java/org/project_kessel/clients/test/TestClientsManagerTest.java
@@ -1,6 +1,13 @@
 package org.project_kessel.clients.test;
 
+import static io.smallrye.common.constraint.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.project_kessel.clients.util.CertUtil.addTestCACertToTrustStore;
+import static org.project_kessel.clients.util.CertUtil.removeTestCACertFromKeystore;
+
 import io.grpc.Metadata;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -10,16 +17,9 @@ import org.project_kessel.clients.authn.AuthenticationConfig;
 import org.project_kessel.clients.authn.oidc.client.OIDCClientCredentialsAuthenticationConfig;
 import org.project_kessel.clients.fake.GrpcServerSpy;
 
-import java.util.Optional;
-
-import static io.smallrye.common.constraint.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.project_kessel.clients.util.CertUtil.addTestCACertToTrustStore;
-import static org.project_kessel.clients.util.CertUtil.removeTestCACertFromKeystore;
-
 public class TestClientsManagerTest {
-    private static final Metadata.Key<String> authorizationKey = Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+    private static final Metadata.Key<String> authorizationKey =
+            Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
 
     @BeforeAll
     static void testSetup() {
@@ -29,47 +29,10 @@ public class TestClientsManagerTest {
         addTestCACertToTrustStore();
     }
 
-    @AfterEach
-    void testTeardown() {
-        /* Make sure all client managers shutdown/removed after each test */
-        TestClientsManager.shutdownAll();
-    }
-
     @AfterAll
     static void removeTestSetup() {
         /* Remove self-signed cert */
         removeTestCACertFromKeystore();
-    }
-
-    @Test
-    void testManagersHoldIntendedCredentialsInChannel() throws Exception {
-        AuthenticationConfig authnConfig = dummyAuthConfigWithGoodOIDCClientCredentials();
-        var manager = TestClientsManager.forInsecureClients("localhost:7000");
-        var manager2 = TestClientsManager.forInsecureClients("localhost:7001", authnConfig);
-        var manager3 = TestClientsManager.forSecureClients("localhost:7002");
-        var manager4 = TestClientsManager.forSecureClients("localhost:7003", authnConfig);
-
-        var testClient = manager.getTestClient();
-        var testClient2 = manager2.getTestClient();
-        var testClient3 = manager3.getTestClient();
-        var testClient4 = manager4.getTestClient();
-
-        var cd1 = GrpcServerSpy.runAgainstTemporaryServerWithDummyServices(7000, () -> testClient.doRpcOne(TestRequest.getDefaultInstance()));
-        var cd2 = GrpcServerSpy.runAgainstTemporaryServerWithDummyServices(7001, () -> testClient2.doRpcOne(TestRequest.getDefaultInstance()));
-        var cd3 = GrpcServerSpy.runAgainstTemporaryTlsServerWithDummyServices(7002, () -> testClient3.doRpcOne(TestRequest.getDefaultInstance()));
-        var cd4 = GrpcServerSpy.runAgainstTemporaryTlsServerWithDummyServices(7003, () -> testClient4.doRpcOne(TestRequest.getDefaultInstance()));
-
-        assertNull(cd1.getMetadata().get(authorizationKey));
-        assertEquals("NONE", cd1.getCall().getSecurityLevel().toString());
-
-        assertNotNull(cd2.getMetadata().get(authorizationKey));
-        assertEquals("NONE", cd2.getCall().getSecurityLevel().toString());
-
-        assertNull(cd3.getMetadata().get(authorizationKey));
-        assertEquals("PRIVACY_AND_INTEGRITY", cd3.getCall().getSecurityLevel().toString());
-
-        assertNotNull(cd4.getMetadata().get(authorizationKey));
-        assertEquals("PRIVACY_AND_INTEGRITY", cd4.getCall().getSecurityLevel().toString());
     }
 
     public static OIDCClientCredentialsAuthenticationConfig dummyAuthConfigWithGoodOIDCClientCredentials() {
@@ -85,5 +48,46 @@ public class TestClientsManagerTest {
         authnConfig.setCredentialsConfig(oidcClientCredentialsConfig);
 
         return authnConfig;
+    }
+
+    @AfterEach
+    void testTeardown() {
+        /* Make sure all client managers shutdown/removed after each test */
+        TestClientsManager.shutdownAll();
+    }
+
+    @Test
+    void testManagersHoldIntendedCredentialsInChannel() throws Exception {
+        AuthenticationConfig authnConfig = dummyAuthConfigWithGoodOIDCClientCredentials();
+        var manager = TestClientsManager.forInsecureClients("localhost:7000");
+        var manager2 = TestClientsManager.forInsecureClients("localhost:7001", authnConfig);
+        var manager3 = TestClientsManager.forSecureClients("localhost:7002");
+        var manager4 = TestClientsManager.forSecureClients("localhost:7003", authnConfig);
+
+        var testClient = manager.getTestClient();
+        var testClient2 = manager2.getTestClient();
+        var testClient3 = manager3.getTestClient();
+        var testClient4 = manager4.getTestClient();
+
+        var cd1 = GrpcServerSpy.runAgainstTemporaryServerWithDummyServices(7000,
+                () -> testClient.doRpcOne(TestRequest.getDefaultInstance()));
+        var cd2 = GrpcServerSpy.runAgainstTemporaryServerWithDummyServices(7001,
+                () -> testClient2.doRpcOne(TestRequest.getDefaultInstance()));
+        var cd3 = GrpcServerSpy.runAgainstTemporaryTlsServerWithDummyServices(7002,
+                () -> testClient3.doRpcOne(TestRequest.getDefaultInstance()));
+        var cd4 = GrpcServerSpy.runAgainstTemporaryTlsServerWithDummyServices(7003,
+                () -> testClient4.doRpcOne(TestRequest.getDefaultInstance()));
+
+        assertNull(cd1.getMetadata().get(authorizationKey));
+        assertEquals("NONE", cd1.getCall().getSecurityLevel().toString());
+
+        assertNotNull(cd2.getMetadata().get(authorizationKey));
+        assertEquals("NONE", cd2.getCall().getSecurityLevel().toString());
+
+        assertNull(cd3.getMetadata().get(authorizationKey));
+        assertEquals("PRIVACY_AND_INTEGRITY", cd3.getCall().getSecurityLevel().toString());
+
+        assertNotNull(cd4.getMetadata().get(authorizationKey));
+        assertEquals("PRIVACY_AND_INTEGRITY", cd4.getCall().getSecurityLevel().toString());
     }
 }

--- a/src/test/java/org/project_kessel/clients/util/CertUtil.java
+++ b/src/test/java/org/project_kessel/clients/util/CertUtil.java
@@ -1,6 +1,12 @@
 package org.project_kessel.clients.util;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -20,8 +26,8 @@ public class CertUtil {
                 return;
             }
 
-            try(InputStream certIn = Thread.currentThread().getContextClassLoader().getResourceAsStream(certFileName);
-                BufferedInputStream bis = new BufferedInputStream(certIn)) {
+            try (InputStream certIn = Thread.currentThread().getContextClassLoader().getResourceAsStream(certFileName);
+                    BufferedInputStream bis = new BufferedInputStream(certIn)) {
 
                 CertificateFactory cf = CertificateFactory.getInstance("X.509");
                 while (bis.available() > 0) {


### PR DESCRIPTION
Similar PR to https://github.com/project-kessel/relations-client-java/pull/18 

All lint configuration options can be found in google_checks.xml
Majority of changes consisted of whitespace spacing issues, removing .* imports, and line limit lengths (120chars)

FILES LINTED: 
- src/main
- src/test

There is a vscode extension where you can right-click on the `google_checks.xml` file to set configuration to help you resolve issues while you code: https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle
(does not auto-format)

Should be able to do the same with setting Intellij and eclipse's formatters to the `google_checks.xml` file
Info on setting up the checkstyle formatting for intellij: https://stackoverflow.com/a/35273850