### PR TITLE
Enable dependabot version updates for maven & github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # to check maven dependencies
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily" # runs MO to FR
+  - package-ecosystem: "github-actions" # to check versions of github actions we use
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enables dependabot to check for updates to our maven & github action dependencies