### PR TITLE
Add no-args contructors for abstract constructors to support quarkus client injection.

### DIFF
--- a/src/main/java/org/project_kessel/clients/KesselClient.java
+++ b/src/main/java/org/project_kessel/clients/KesselClient.java
@@ -7,6 +7,15 @@ public abstract class KesselClient<A extends AbstractAsyncStub<A>, B extends Abs
     protected A asyncStub;
     protected B blockingStub;
 
+    /***
+     * No args constructor to support synthetic creation of no-args constructor in CDI in impls for normal scope bean
+     * proxying. Supports producers (@Produces) of @ApplicationScoped beans in containers like Quarkus.
+     * (https://github.com/quarkusio/quarkus/issues/22669#issuecomment-1006147659)
+     */
+    protected KesselClient() {
+
+    }
+
     protected KesselClient(A asyncStub, B blockingStub) {
         this.asyncStub = asyncStub;
         this.blockingStub = blockingStub;

--- a/src/main/java/org/project_kessel/clients/KesselClientsManager.java
+++ b/src/main/java/org/project_kessel/clients/KesselClientsManager.java
@@ -3,7 +3,16 @@ package org.project_kessel.clients;
 import io.grpc.Channel;
 
 public abstract class KesselClientsManager {
-    protected final Channel channel;
+    protected Channel channel;
+
+    /***
+     * No args constructor to support synthetic creation of no-args constructor in CDI in impls for normal scope bean
+     * proxying. Supports producers (@Produces) of @ApplicationScoped beans in containers like Quarkus.
+     * (https://github.com/quarkusio/quarkus/issues/22669#issuecomment-1006147659)
+     */
+    protected KesselClientsManager() {
+
+    }
 
     protected KesselClientsManager(Channel channel) {
         this.channel = channel;


### PR DESCRIPTION
This is an enabler for @ApplicationScoped beans in the java clients using this library.

Code comment mostly says it:
/***
 * No args constructor to support synthetic creation of no-args constructor in CDI in impls for normal scope bean
 * proxying. Supports producers (@Produces) of @ApplicationScoped beans in containers like Quarkus.
 * (https://github.com/quarkusio/quarkus/issues/22669#issuecomment-1006147659)
 */